### PR TITLE
Set the client on boot(_ drop:)

### DIFF
--- a/Sources/UAPusher/ConnectionManager.swift
+++ b/Sources/UAPusher/ConnectionManager.swift
@@ -5,14 +5,14 @@ import Vapor
 
 public final class ConnectionManager {
     static let baseUrl = "https://go.urbanairship.com"
-    internal var client: ClientProtocol?
+    private let client: ClientProtocol
     private let config: UAPusherConfig
     
     public init(
         config: UAPusherConfig,
-        clientFactory: ClientFactoryProtocol? = nil
+        clientFactory: ClientFactoryProtocol
     ) throws {
-        client = try clientFactory?.makeClient(
+        client = try clientFactory.makeClient(
             hostname: ConnectionManager.baseUrl,
             port: 443,
             securityLayer: .tls(Context(.client))
@@ -53,10 +53,6 @@ public final class ConnectionManager {
     /// - Returns: array of Status for each request made
     /// - Throws: if POST fails
     func post(slug: String, content: JSON) throws -> [Response] {
-        guard let client = client else {
-            throw Abort(.internalServerError, reason: "Client is not set up")
-        }
-
         let url = ConnectionManager.baseUrl + slug
         let body = content.makeBody()
         

--- a/Sources/UAPusher/ConnectionManager.swift
+++ b/Sources/UAPusher/ConnectionManager.swift
@@ -1,13 +1,22 @@
-import Vapor
-import HTTP
 import Foundation
+import HTTP
+import TLS
+import Vapor
 
 public final class ConnectionManager {
     static let baseUrl = "https://go.urbanairship.com"
     internal var client: ClientProtocol?
     private let config: UAPusherConfig
     
-    public init(config: UAPusherConfig) throws {
+    public init(
+        config: UAPusherConfig,
+        clientFactory: ClientFactoryProtocol? = nil
+    ) throws {
+        client = try clientFactory?.makeClient(
+            hostname: ConnectionManager.baseUrl,
+            port: 443,
+            securityLayer: .tls(Context(.client))
+        )
         self.config = config
     }
     

--- a/Sources/UAPusher/ConnectionManager.swift
+++ b/Sources/UAPusher/ConnectionManager.swift
@@ -1,20 +1,14 @@
 import Vapor
 import HTTP
 import Foundation
-import TLS
 
 public final class ConnectionManager {
     static let baseUrl = "https://go.urbanairship.com"
-    private let client: ClientProtocol
+    internal var client: ClientProtocol?
     private let config: UAPusherConfig
     
-    public init(clientFactory: ClientFactoryProtocol, config: UAPusherConfig) throws {
+    public init(config: UAPusherConfig) throws {
         self.config = config
-        self.client = try clientFactory.makeClient(
-            hostname: ConnectionManager.baseUrl,
-            port: 443,
-            securityLayer: .tls(Context(.client))
-        )
     }
     
     /// Defines the headers of the request with the given appKey and
@@ -50,7 +44,10 @@ public final class ConnectionManager {
     /// - Returns: array of Status for each request made
     /// - Throws: if POST fails
     func post(slug: String, content: JSON) throws -> [Response] {
-        
+        guard let client = client else {
+            throw Abort(.internalServerError, reason: "Client is not set up")
+        }
+
         let url = ConnectionManager.baseUrl + slug
         let body = content.makeBody()
         

--- a/Sources/UAPusher/Provider.swift
+++ b/Sources/UAPusher/Provider.swift
@@ -1,3 +1,4 @@
+import TLS
 import Vapor
 
 public final class Provider: Vapor.Provider {
@@ -5,16 +6,22 @@ public final class Provider: Vapor.Provider {
     public static var repositoryName: String = "uapusher"
     private var connectionManager: ConnectionManager
 
-    public func boot(_ config: Config) throws {}
+    public func boot(_ config: Vapor.Config) throws {}
 
     public func boot(_ drop: Droplet) throws {
+        connectionManager.client = try drop.config.resolveClient().makeClient(
+            hostname: ConnectionManager.baseUrl,
+            port: 443,
+            securityLayer: .tls(Context(.client))
+        )
+
         drop.uapusher = UAManager(connectionManager: connectionManager)
     }
     
-    public init(config: Config) throws {
+    public init(config: Vapor.Config) throws {
         self.config = try UAPusherConfig(config: config)
+
         connectionManager = try ConnectionManager(
-            clientFactory: config.resolveClient(),
             config: self.config
         )
     }

--- a/Sources/UAPusher/Provider.swift
+++ b/Sources/UAPusher/Provider.swift
@@ -4,15 +4,13 @@ import Vapor
 public final class Provider: Vapor.Provider {
     let config: UAPusherConfig
     public static var repositoryName: String = "uapusher"
-    private var connectionManager: ConnectionManager
 
     public func boot(_ config: Vapor.Config) throws {}
 
     public func boot(_ drop: Droplet) throws {
-        connectionManager.client = try drop.config.resolveClient().makeClient(
-            hostname: ConnectionManager.baseUrl,
-            port: 443,
-            securityLayer: .tls(Context(.client))
+        let connectionManager = try ConnectionManager(
+            config: self.config,
+            clientFactory: drop.config.resolveClient()
         )
 
         drop.uapusher = UAManager(connectionManager: connectionManager)
@@ -20,10 +18,6 @@ public final class Provider: Vapor.Provider {
     
     public init(config: Vapor.Config) throws {
         self.config = try UAPusherConfig(config: config)
-
-        connectionManager = try ConnectionManager(
-            config: self.config
-        )
     }
 
     /// Called before the Droplet begins serving

--- a/Sources/UAPusher/Provider.swift
+++ b/Sources/UAPusher/Provider.swift
@@ -1,11 +1,10 @@
-import TLS
 import Vapor
 
 public final class Provider: Vapor.Provider {
     let config: UAPusherConfig
     public static var repositoryName: String = "uapusher"
 
-    public func boot(_ config: Vapor.Config) throws {}
+    public func boot(_ config: Config) throws {}
 
     public func boot(_ drop: Droplet) throws {
         let connectionManager = try ConnectionManager(
@@ -16,7 +15,7 @@ public final class Provider: Vapor.Provider {
         drop.uapusher = UAManager(connectionManager: connectionManager)
     }
     
-    public init(config: Vapor.Config) throws {
+    public init(config: Config) throws {
         self.config = try UAPusherConfig(config: config)
     }
 


### PR DESCRIPTION
Workaround for Client not being available at config time. Configure everything as before but set client in boot(_ drop:) phase.