### PR TITLE
Fix potential Fatal Error

### DIFF
--- a/Sources/UAPusher/Provider.swift
+++ b/Sources/UAPusher/Provider.swift
@@ -1,3 +1,4 @@
+import HTTP
 import Vapor
 
 public final class Provider: Vapor.Provider {
@@ -9,7 +10,7 @@ public final class Provider: Vapor.Provider {
     public func boot(_ drop: Droplet) throws {
         let connectionManager = try ConnectionManager(
             config: self.config,
-            clientFactory: drop.config.resolveClient()
+            clientFactory: FoundationClientFactory()
         )
 
         drop.uapusher = UAManager(connectionManager: connectionManager)


### PR DESCRIPTION
UAPusher will never work if the `client` is set to `engine` within `droplet.json`.
So instead of resolving the clientFactory from the drops config hoping it is set to `foundation` we could use the `FoundationClientFactory()` right away and it will always work 🚀